### PR TITLE
Fix SequenceLengthMismatch in Sequence::new

### DIFF
--- a/src/value/sequence.rs
+++ b/src/value/sequence.rs
@@ -25,7 +25,13 @@ impl Sequence {
     
     pub fn new(definition: Tuple, values: &[ValueCell]) -> TypeResult<Self> {
         if definition.len() != values.len() {
-            return Err(SequenceError::SequenceLengthMismatch { expected: 0, provided: 0 }.promote());
+            return Err(
+                SequenceError::SequenceLengthMismatch {
+                    expected: definition.len(),
+                    provided: values.len(),
+                }
+                .promote(),
+            );
         }
         for (index, expected) in definition.iter().enumerate() {
             values[index].borrow().validate_type(expected)?;


### PR DESCRIPTION
## Summary
- ensure Sequence::new reports correct expected and provided lengths

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6848d188a658832fbc01e4152d326883